### PR TITLE
Calcul de l'ancienneté d'un employé 

### DIFF
--- a/src/main/java/com/ipiecoles/java/java350/model/Employe.java
+++ b/src/main/java/com/ipiecoles/java/java350/model/Employe.java
@@ -43,9 +43,20 @@ public class Employe {
         this.tempsPartiel = tempsPartiel;
     }
 
+    /**
+     * On calcul en nombre d'années par rapport à l'année d'embauche initiale de l'employé.
+     * On se base uniquement sur l'année.
+     * On considère que l'employé n'a pas quitté l'entreprise entre temps.
+     * Lors du départ d'un employé, celui-ci est supprimé de la base.
+     *
+     * @return le nombre d'année d'ancienneté de l'employé
+     */
     public Integer getNombreAnneeAnciennete() {
-        //TODO
-        return null;
+        if(this.dateEmbauche != null && this.dateEmbauche.isBefore(LocalDate.now())){
+            return LocalDate.now().getYear() - this.dateEmbauche.getYear();
+        }
+        //0 année d'ancienneté en cas de date d'embauche non fournie ou future
+        return 0;
     }
 
     public Integer getNbConges() {

--- a/src/test/java/com/ipiecoles/java/java350/model/EmployeTest.java
+++ b/src/test/java/com/ipiecoles/java/java350/model/EmployeTest.java
@@ -1,0 +1,69 @@
+package com.ipiecoles.java.java350.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+public class EmployeTest {
+
+    @Test
+    //Embauché en 2020. On est en 2020 : 0 an ancienneté
+    public void testNombreAnneeAncienneteNow(){
+        //Given
+        LocalDate now = LocalDate.now();
+        Employe employe = new Employe();
+        employe.setDateEmbauche(now);
+
+        //When
+        Integer nbAnneesAnciennete = employe.getNombreAnneeAnciennete();
+
+        //Then
+        Assertions.assertThat(nbAnneesAnciennete).isEqualTo(0);
+    }
+
+    @Test
+    //Embauché en 2019. On est en 2020 : 1 an ancienneté
+    public void testNombreAnneeAncienneteNMoins1(){
+        //Given
+        LocalDate nMoins1 = LocalDate.now().minusYears(1);
+        Employe employe = new Employe();
+        employe.setDateEmbauche(nMoins1);
+
+        //When
+        Integer nbAnneesAnciennete = employe.getNombreAnneeAnciennete();
+
+        //Then
+        Assertions.assertThat(nbAnneesAnciennete).isEqualTo(1);
+    }
+
+    @Test
+    //Embauché en 2021. On est en 2020 : 0 an ancienneté
+    public void testNombreAnneeAncienneteNPlus1(){
+        //Given
+        LocalDate nPlus1 = LocalDate.now().plusYears(1);
+        Employe employe = new Employe();
+        employe.setDateEmbauche(nPlus1);
+
+        //When
+        Integer nbAnneesAnciennete = employe.getNombreAnneeAnciennete();
+
+        //Then
+        Assertions.assertThat(nbAnneesAnciennete).isEqualTo(0);
+    }
+
+    @Test
+    //Embauché en 2021. On est en 2020 : 0 an ancienneté
+    public void testNombreAnneeAncienneteNull(){
+        //Given
+        Employe employe = new Employe();
+        employe.setDateEmbauche(null);
+
+        //When
+        Integer nbAnneesAnciennete = employe.getNombreAnneeAnciennete();
+
+        //Then
+        Assertions.assertThat(nbAnneesAnciennete).isEqualTo(0);
+    }
+
+}


### PR DESCRIPTION
On calcul en nombre d'années par rapport à l'année d'embauche initiale de l'employé. On se base uniquement sur l'année. On considère que l'employé n'a pas quitté l'entreprise entre temps. Lors du départ d'un employé, celui-ci est supprimé de la base.

Critères d'acceptation
- [x] Embauché en 2019. On est en 2020 : 1 an ancienneté
- [x] Embauché en 2020. On est en 2020 : 0 an ancienneté
- [x] Pas de date d'embauche : 0 année d'ancienneté
- [x] Date d'embauche dans le futur : 0 année d'ancienneté
- [x] JavaDoc OK
- [x] Sonar OK
- [x] Couverture 100%